### PR TITLE
Pass image data directly to `ZlibStream`, bypassing `ChunkState::raw_bytes`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -40,14 +40,14 @@ jobs:
         cargo check --tests --no-default-features --features="$FEATURES"
       env:
         FEATURES: ${{ matrix.features }}
-  mips_cross:
+  powerpc_cross:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - name: add_cross_target
       run: |
-        rustup target add mips64-unknown-linux-gnuabi64
-        cargo build --all-features --target mips64-unknown-linux-gnuabi64
+        rustup target add powerpc-unknown-linux-gnu
+        cargo build --target powerpc-unknown-linux-gnu
   test_all:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -55,7 +55,7 @@ jobs:
     - run: rustup default stable
     - name: test
       run: >
-        cargo test -v --all-targets --all-features
+        cargo test -v --all-targets
   rustfmt:
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ flate2 = "1.0"
 miniz_oxide = { version = "0.7.1", features = ["simd"] }
 
 [dev-dependencies]
+byteorder = "1.5.0"
 clap = { version = "3.0", features = ["derive"] }
 criterion = "0.3.1"
 getopts = "0.2.14"

--- a/benches/png_generator.rs
+++ b/benches/png_generator.rs
@@ -1,0 +1,93 @@
+use byteorder::WriteBytesExt;
+use std::io::Write;
+
+/// Generates a store-only, non-compressed image:
+///
+/// * `00` compression mode (i.e.`BTYPE` = `00` = no compression) is used
+/// * No filter is applied to the image rows
+///
+/// Currently the image always has the following properties:
+///
+/// * Single `IDAT` chunk
+/// * Zlib chunks of maximum possible size
+/// * 8-bit RGBA
+///
+/// These images are somewhat artificial, but may be useful for benchmarking performance of parts
+/// outside of `fdeflate` crate and/or the `unfilter` function (e.g. these images were originally
+/// used to evaluate changes to minimize copying of image pixels between various buffers - see
+/// [this
+/// discussion](https://github.com/image-rs/image-png/discussions/416#discussioncomment-7436871)
+/// for more details).
+pub fn write_noncompressed_png(w: &mut impl Write, width: u32) {
+    write_png_sig(w);
+    write_ihdr(w, width);
+    write_noncompressed_idat(w, width);
+    write_iend(w);
+}
+
+fn write_png_sig(w: &mut impl Write) {
+    const SIG: [u8; 8] = [137, 80, 78, 71, 13, 10, 26, 10];
+    w.write_all(&SIG).unwrap();
+}
+
+fn write_chunk(w: &mut impl Write, chunk_type: &[u8], data: &[u8]) {
+    let crc = {
+        let input = chunk_type
+            .iter()
+            .copied()
+            .chain(data.iter().copied())
+            .collect::<Vec<_>>();
+        crc32fast::hash(input.as_slice())
+    };
+    w.write_u32::<byteorder::BigEndian>(data.len() as u32)
+        .unwrap();
+    w.write_all(chunk_type).unwrap();
+    w.write_all(data).unwrap();
+    w.write_u32::<byteorder::BigEndian>(crc).unwrap();
+}
+
+fn write_ihdr(w: &mut impl Write, width: u32) {
+    let mut data = Vec::new();
+    data.write_u32::<byteorder::BigEndian>(width).unwrap();
+    data.write_u32::<byteorder::BigEndian>(width).unwrap(); // height
+    data.write_u8(8).unwrap(); // bit depth = always 8-bits per channel
+    data.write_u8(6).unwrap(); // color type = color + alpha
+    data.write_u8(0).unwrap(); // compression method (0 is the only allowed value)
+    data.write_u8(0).unwrap(); // filter method (0 is the only allowed value)
+    data.write_u8(0).unwrap(); // interlace method = no interlacing
+    write_chunk(w, b"IHDR", &data);
+}
+
+fn write_noncompressed_idat(w: &mut impl Write, width: u32) {
+    // Generate arbitrary test pixels.
+    let image_pixels = {
+        let mut row = Vec::new();
+        row.write_u8(0).unwrap(); // filter = no filter
+
+        let row_pixels = (0..width)
+            .map(|i| {
+                let color: u8 = (i * 255 / width) as u8;
+                let alpha: u8 = 0xff;
+                [color, 255 - color, color / 2, alpha]
+            })
+            .flatten();
+        row.extend(row_pixels);
+
+        std::iter::repeat(row)
+            .take(width as usize)
+            .flatten()
+            .collect::<Vec<_>>()
+    };
+
+    let mut zlib_data = Vec::new();
+    let mut store_only_compressor =
+        fdeflate::StoredOnlyCompressor::new(std::io::Cursor::new(&mut zlib_data)).unwrap();
+    store_only_compressor.write_data(&image_pixels).unwrap();
+    store_only_compressor.finish().unwrap();
+
+    write_chunk(w, b"IDAT", &zlib_data);
+}
+
+fn write_iend(w: &mut impl Write) {
+    write_chunk(w, b"IEND", &[]);
+}

--- a/benches/unfilter.rs
+++ b/benches/unfilter.rs
@@ -2,9 +2,9 @@
 //!
 //! ```
 //! $ alias bench="rustup run nightly cargo bench"
-//! $ bench --bench=unfilter --features=benchmarks -- --save-baseline my_baseline
+//! $ bench --bench=unfilter --features=benchmarks,unstable -- --save-baseline my_baseline
 //! ... tweak something, say the Sub filter ...
-//! $ bench --bench=unfilter --features=benchmarks -- filter=Sub --baseline my_baseline
+//! $ bench --bench=unfilter --features=benchmarks,unstable -- filter=Sub --baseline my_baseline
 //! ```
 
 use criterion::{criterion_group, criterion_main, Criterion, Throughput};

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1525,6 +1525,12 @@ impl<'a, W: Write> StreamWriter<'a, W> {
         }
     }
 
+    /// Consume the stream writer with validation.
+    ///
+    /// Unlike a simple drop this ensures that the all data was written correctly. When other
+    /// validation options (chunk sequencing) had been turned on in the configuration of inner
+    /// [`Writer`], then it will also do a check on their correctness. Differently from
+    /// [`Writer::finish`], this just `flush`es, returns error if some data is abandoned.
     pub fn finish(mut self) -> Result<()> {
         if self.to_write > 0 {
             let err = FormatErrorKind::MissingData(self.to_write).into();

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -2,6 +2,170 @@ use core::convert::TryInto;
 
 use crate::common::BytesPerPixel;
 
+/// SIMD helpers for `fn unfilter`
+///
+/// TODO(https://github.com/rust-lang/rust/issues/86656): Stop gating this module behind the
+/// "unstable" feature of the `png` crate.  This should be possible once the "portable_simd"
+/// feature of Rust gets stabilized.
+#[cfg(feature = "unstable")]
+mod simd {
+    use std::simd::{
+        u8x4, u8x8, LaneCount, Simd, SimdInt, SimdOrd, SimdPartialEq, SimdUint, SupportedLaneCount,
+    };
+
+    /// This is an equivalent of the `PaethPredictor` function from
+    /// [the spec](http://www.libpng.org/pub/png/spec/1.2/PNG-Filters.html#Filter-type-4-Paeth)
+    /// except that it simultaenously calculates the predictor for all SIMD lanes.
+    /// Mapping between parameter names and pixel positions can be found in
+    /// [a diagram here](https://www.w3.org/TR/png/#filter-byte-positions).
+    ///
+    /// Examples of how different pixel types may be represented as multiple SIMD lanes:
+    /// - RGBA => 4 lanes of `i16x4` contain R, G, B, A
+    /// - RGB  => 4 lanes of `i16x4` contain R, G, B, and a ignored 4th value
+    ///
+    /// The SIMD algorithm below is based on [`libpng`](https://github.com/glennrp/libpng/blob/f8e5fa92b0e37ab597616f554bee254157998227/intel/filter_sse2_intrinsics.c#L261-L280).
+    fn paeth_predictor<const N: usize>(
+        a: Simd<i16, N>,
+        b: Simd<i16, N>,
+        c: Simd<i16, N>,
+    ) -> Simd<i16, N>
+    where
+        LaneCount<N>: SupportedLaneCount,
+    {
+        let pa = b - c; // (p-a) == (a+b-c - a) == (b-c)
+        let pb = a - c; // (p-b) == (a+b-c - b) == (a-c)
+        let pc = pa + pb; // (p-c) == (a+b-c - c) == (a+b-c-c) == (b-c)+(a-c)
+
+        let pa = pa.abs();
+        let pb = pb.abs();
+        let pc = pc.abs();
+
+        let smallest = pc.simd_min(pa.simd_min(pb));
+
+        // Paeth algorithm breaks ties favoring a over b over c, so we execute the following
+        // lane-wise selection:
+        //
+        //     if smalest == pa
+        //         then select a
+        //         else select (if smallest == pb then select b else select c)
+        smallest
+            .simd_eq(pa)
+            .select(a, smallest.simd_eq(pb).select(b, c))
+    }
+
+    /// Memory of previous pixels (as needed to unfilter `FilterType::Paeth`).
+    /// See also https://www.w3.org/TR/png/#filter-byte-positions
+    #[derive(Default)]
+    struct PaethState<const N: usize>
+    where
+        LaneCount<N>: SupportedLaneCount,
+    {
+        /// Previous pixel in the previous row.
+        c: Simd<i16, N>,
+
+        /// Previous pixel in the current row.
+        a: Simd<i16, N>,
+    }
+
+    /// Mutates `x` as needed to unfilter `FilterType::Paeth`.
+    ///
+    /// `b` is the current pixel in the previous row.  `x` is the current pixel in the current row.
+    /// See also https://www.w3.org/TR/png/#filter-byte-positions
+    fn paeth_step<const N: usize>(state: &mut PaethState<N>, b: Simd<u8, N>, x: &mut Simd<u8, N>)
+    where
+        LaneCount<N>: SupportedLaneCount,
+    {
+        // Storing the inputs.
+        let b = b.cast::<i16>();
+
+        // Calculating the new value of the current pixel.
+        let predictor = paeth_predictor(state.a, b, state.c);
+        *x += predictor.cast::<u8>();
+
+        // Preparing for the next step.
+        state.c = b;
+        state.a = x.cast::<i16>();
+    }
+
+    fn load3(src: &[u8]) -> u8x4 {
+        u8x4::from_array([src[0], src[1], src[2], 0])
+    }
+
+    fn store3(src: u8x4, dest: &mut [u8]) {
+        dest[0..3].copy_from_slice(&src.to_array()[0..3])
+    }
+
+    /// Undoes `FilterType::Paeth` for `BytesPerPixel::Three`.
+    pub fn unfilter_paeth3(mut prev_row: &[u8], mut curr_row: &mut [u8]) {
+        debug_assert_eq!(prev_row.len(), curr_row.len());
+        debug_assert_eq!(prev_row.len() % 3, 0);
+
+        let mut state = PaethState::<4>::default();
+        while prev_row.len() >= 4 {
+            // `u8x4` requires working with `[u8;4]`, but we can just load and ignore the first
+            // byte from the next triple.  This optimization technique mimics the algorithm found
+            // in
+            // https://github.com/glennrp/libpng/blob/f8e5fa92b0e37ab597616f554bee254157998227/intel/filter_sse2_intrinsics.c#L130-L131
+            let b = u8x4::from_slice(prev_row);
+            let mut x = u8x4::from_slice(curr_row);
+
+            paeth_step(&mut state, b, &mut x);
+
+            // We can speculate that writing 4 bytes might be more efficient (just as with using
+            // `u8x4::from_slice` above), but we can't use that here, because we can't clobber the
+            // first byte of the next pixel in the `curr_row`.
+            store3(x, curr_row);
+
+            prev_row = &prev_row[3..];
+            curr_row = &mut curr_row[3..];
+        }
+        // Can't use `u8x4::from_slice` for the last `[u8;3]`.
+        let b = load3(prev_row);
+        let mut x = load3(curr_row);
+        paeth_step(&mut state, b, &mut x);
+        store3(x, curr_row);
+    }
+
+    fn load6(src: &[u8]) -> u8x8 {
+        u8x8::from_array([src[0], src[1], src[2], src[3], src[4], src[5], 0, 0])
+    }
+
+    fn store6(src: u8x8, dest: &mut [u8]) {
+        dest[0..6].copy_from_slice(&src.to_array()[0..6])
+    }
+
+    /// Undoes `FilterType::Paeth` for `BytesPerPixel::Six`.
+    pub fn unfilter_paeth6(mut prev_row: &[u8], mut curr_row: &mut [u8]) {
+        debug_assert_eq!(prev_row.len(), curr_row.len());
+        debug_assert_eq!(prev_row.len() % 6, 0);
+
+        let mut state = PaethState::<8>::default();
+        while prev_row.len() >= 8 {
+            // `u8x8` requires working with `[u8;8]`, but we can just load and ignore the first two
+            // bytes from the next pixel.  This optimization technique mimics the algorithm found
+            // in
+            // https://github.com/glennrp/libpng/blob/f8e5fa92b0e37ab597616f554bee254157998227/intel/filter_sse2_intrinsics.c#L130-L131
+            let b = u8x8::from_slice(prev_row);
+            let mut x = u8x8::from_slice(curr_row);
+
+            paeth_step(&mut state, b, &mut x);
+
+            // We can speculate that writing 8 bytes might be more efficient (just as with using
+            // `u8x8::from_slice` above), but we can't use that here, because we can't clobber the
+            // first bytes of the next pixel in the `curr_row`.
+            store6(x, curr_row);
+
+            prev_row = &prev_row[6..];
+            curr_row = &mut curr_row[6..];
+        }
+        // Can't use `u8x8::from_slice` for the last `[u8;6]`.
+        let b = load6(prev_row);
+        let mut x = load6(curr_row);
+        paeth_step(&mut state, b, &mut x);
+        store6(x, curr_row);
+    }
+}
+
 /// The byte level filter applied to scanlines to prepare them for compression.
 ///
 /// Compression in general benefits from repetitive data. The filter is a content-aware method of
@@ -401,21 +565,31 @@ pub(crate) fn unfilter(
                     }
                 }
                 BytesPerPixel::Three => {
-                    let mut a_bpp = [0; 3];
-                    let mut c_bpp = [0; 3];
-                    for (chunk, b_bpp) in current.chunks_exact_mut(3).zip(previous.chunks_exact(3))
+                    #[cfg(feature = "unstable")]
+                    simd::unfilter_paeth3(previous, current);
+
+                    #[cfg(not(feature = "unstable"))]
                     {
-                        let new_chunk = [
-                            chunk[0]
-                                .wrapping_add(filter_paeth_decode(a_bpp[0], b_bpp[0], c_bpp[0])),
-                            chunk[1]
-                                .wrapping_add(filter_paeth_decode(a_bpp[1], b_bpp[1], c_bpp[1])),
-                            chunk[2]
-                                .wrapping_add(filter_paeth_decode(a_bpp[2], b_bpp[2], c_bpp[2])),
-                        ];
-                        *TryInto::<&mut [u8; 3]>::try_into(chunk).unwrap() = new_chunk;
-                        a_bpp = new_chunk;
-                        c_bpp = b_bpp.try_into().unwrap();
+                        let mut a_bpp = [0; 3];
+                        let mut c_bpp = [0; 3];
+                        for (chunk, b_bpp) in
+                            current.chunks_exact_mut(3).zip(previous.chunks_exact(3))
+                        {
+                            let new_chunk = [
+                                chunk[0].wrapping_add(filter_paeth_decode(
+                                    a_bpp[0], b_bpp[0], c_bpp[0],
+                                )),
+                                chunk[1].wrapping_add(filter_paeth_decode(
+                                    a_bpp[1], b_bpp[1], c_bpp[1],
+                                )),
+                                chunk[2].wrapping_add(filter_paeth_decode(
+                                    a_bpp[2], b_bpp[2], c_bpp[2],
+                                )),
+                            ];
+                            *TryInto::<&mut [u8; 3]>::try_into(chunk).unwrap() = new_chunk;
+                            a_bpp = new_chunk;
+                            c_bpp = b_bpp.try_into().unwrap();
+                        }
                     }
                 }
                 BytesPerPixel::Four => {
@@ -439,27 +613,40 @@ pub(crate) fn unfilter(
                     }
                 }
                 BytesPerPixel::Six => {
-                    let mut a_bpp = [0; 6];
-                    let mut c_bpp = [0; 6];
-                    for (chunk, b_bpp) in current.chunks_exact_mut(6).zip(previous.chunks_exact(6))
+                    #[cfg(feature = "unstable")]
+                    simd::unfilter_paeth6(previous, current);
+
+                    #[cfg(not(feature = "unstable"))]
                     {
-                        let new_chunk = [
-                            chunk[0]
-                                .wrapping_add(filter_paeth_decode(a_bpp[0], b_bpp[0], c_bpp[0])),
-                            chunk[1]
-                                .wrapping_add(filter_paeth_decode(a_bpp[1], b_bpp[1], c_bpp[1])),
-                            chunk[2]
-                                .wrapping_add(filter_paeth_decode(a_bpp[2], b_bpp[2], c_bpp[2])),
-                            chunk[3]
-                                .wrapping_add(filter_paeth_decode(a_bpp[3], b_bpp[3], c_bpp[3])),
-                            chunk[4]
-                                .wrapping_add(filter_paeth_decode(a_bpp[4], b_bpp[4], c_bpp[4])),
-                            chunk[5]
-                                .wrapping_add(filter_paeth_decode(a_bpp[5], b_bpp[5], c_bpp[5])),
-                        ];
-                        *TryInto::<&mut [u8; 6]>::try_into(chunk).unwrap() = new_chunk;
-                        a_bpp = new_chunk;
-                        c_bpp = b_bpp.try_into().unwrap();
+                        let mut a_bpp = [0; 6];
+                        let mut c_bpp = [0; 6];
+                        for (chunk, b_bpp) in
+                            current.chunks_exact_mut(6).zip(previous.chunks_exact(6))
+                        {
+                            let new_chunk = [
+                                chunk[0].wrapping_add(filter_paeth_decode(
+                                    a_bpp[0], b_bpp[0], c_bpp[0],
+                                )),
+                                chunk[1].wrapping_add(filter_paeth_decode(
+                                    a_bpp[1], b_bpp[1], c_bpp[1],
+                                )),
+                                chunk[2].wrapping_add(filter_paeth_decode(
+                                    a_bpp[2], b_bpp[2], c_bpp[2],
+                                )),
+                                chunk[3].wrapping_add(filter_paeth_decode(
+                                    a_bpp[3], b_bpp[3], c_bpp[3],
+                                )),
+                                chunk[4].wrapping_add(filter_paeth_decode(
+                                    a_bpp[4], b_bpp[4], c_bpp[4],
+                                )),
+                                chunk[5].wrapping_add(filter_paeth_decode(
+                                    a_bpp[5], b_bpp[5], c_bpp[5],
+                                )),
+                            ];
+                            *TryInto::<&mut [u8; 6]>::try_into(chunk).unwrap() = new_chunk;
+                            a_bpp = new_chunk;
+                            c_bpp = b_bpp.try_into().unwrap();
+                        }
                     }
                 }
                 BytesPerPixel::Eight => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,7 @@
 //! ```
 //!
 
+#![cfg_attr(feature = "unstable", feature(portable_simd))]
 #![forbid(unsafe_code)]
 
 #[macro_use]

--- a/tests/benches/README.md
+++ b/tests/benches/README.md
@@ -1,12 +1,13 @@
 Copyrights:
 
-Lohengrin_-_Illustrated_Sporting_and_Dramatic_News.png: Public Domain, according to Wikimedia
-kodim*.png: Eastman Kodak Company, released for unrestricted use
-Transparency.png: Public Domain, according to Wikimedia
+* `Lohengrin_-_Illustrated_Sporting_and_Dramatic_News.png`: Public Domain, according to Wikimedia
+* `kodim*.png`: Eastman Kodak Company, released for unrestricted use
+* `Transparency.png`: Public Domain, according to Wikimedia
 
 The images use different filtering:
-Lohengrin: no filtering
-kodim02: mixed
-kodim07: mainly paeth
-kodim17: mainly sub
-kodim23: mixed
+
+* Lohengrin: no filtering
+* kodim02: mixed
+* kodim07: mainly paeth
+* kodim17: mainly sub
+* kodim23: mixed


### PR DESCRIPTION
PTAL?  Please note that this is [a stacked/chained PR](https://blog.logrocket.com/using-stacked-pull-requests-in-github/) (i.e. *this* PR depends on first reviewing and landing the other PR here: https://github.com/image-rs/image-png/pull/420). For more details, background, and motivation, please see the description of [the 3rd commit](https://github.com/image-rs/image-png/commit/57f4f3f8506d60858d03b1eee42c69287bd75dac) in this PR.